### PR TITLE
Use absolute path to set .ipynb file as dependency

### DIFF
--- a/nbsphinx_link/__init__.py
+++ b/nbsphinx_link/__init__.py
@@ -196,7 +196,7 @@ class LinkedNotebookParser(NotebookParser):
             source_file = env.doc2path(env.docname)
             collect_extra_media(extra_media, source_file, path, document)
 
-        register_dependency(path, document)
+        register_dependency(abs_path, document)
 
         target_root = env.config.nbsphinx_link_target_root
         target = utils.relative_path(target_root, abs_path)


### PR DESCRIPTION
Getting the relative path seems to be broken, but Sphinx seems to be fine with absolute paths as well.

With a bit of luck, this fixes https://github.com/mgeier/sphinx-last-updated-by-git/issues/26.