### PR TITLE
Fix of breaking change with `docutils`: `docutils.nodes.reprunicode` removed with version 0.21

### DIFF
--- a/nbsphinx_link/__init__.py
+++ b/nbsphinx_link/__init__.py
@@ -189,7 +189,6 @@ class LinkedNotebookParser(NotebookParser):
 
         abs_path = os.path.normpath(os.path.join(source_dir, link['path']))
         path = utils.relative_path(None, abs_path)
-        path = nodes.reprunicode(path)
 
         extra_media = link.get('extra-media', None)
         if extra_media:
@@ -200,7 +199,7 @@ class LinkedNotebookParser(NotebookParser):
 
         target_root = env.config.nbsphinx_link_target_root
         target = utils.relative_path(target_root, abs_path)
-        target = nodes.reprunicode(target).replace(os.path.sep, '/')
+        target = target.replace(os.path.sep, '/')
         env.metadata[env.docname]['nbsphinx-link-target'] = target
 
         # Copy parser from nbsphinx for our cutom format


### PR DESCRIPTION
Hi, 

I like to use nbsphinx-link for building my docs, but got an `AttributeError: module 'docutils.nodes' has no attribute 'reprunicode'` today. I realized that `nbsphinx-link/__init__.py::LinkedNotebookParser` uses `docutils.nodes.reprunicode`, which was [removed as of `docutils` v0.21](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09), as being a 'Python 2 compatibility hack'. 

Indeed, just leaving it out will fix the bug, which is what I did in the below commit. Hope to make a useful contribution.

Cheers, F

*Edit: See #22 for a better approach maintaining Python 2 compatibility.*